### PR TITLE
Make isWindowsProcessAlive check username of process matches expected…

### DIFF
--- a/storm-core/src/jvm/org/apache/storm/daemon/supervisor/Container.java
+++ b/storm-core/src/jvm/org/apache/storm/daemon/supervisor/Container.java
@@ -191,7 +191,8 @@ public abstract class Container implements Killable {
                     //Example line: "User Name:    exampleDomain\exampleUser"
                     List<String> userNameLineSplitOnWhitespace = Arrays.asList(read.split(":"));
                     if(userNameLineSplitOnWhitespace.size() == 2){
-                        String processUser = userNameLineSplitOnWhitespace.get(1).trim();
+                        List<String> userAndMaybeDomain = Arrays.asList(userNameLineSplitOnWhitespace.get(1).trim().split("\\\\"));
+                        String processUser = userAndMaybeDomain.size() == 2 ? userAndMaybeDomain.get(1) : userAndMaybeDomain.get(0);
                         if(user.equals(processUser)){
                             ret = true;
                         } else {

--- a/storm-core/src/jvm/org/apache/storm/daemon/supervisor/Container.java
+++ b/storm-core/src/jvm/org/apache/storm/daemon/supervisor/Container.java
@@ -19,14 +19,12 @@ package org.apache.storm.daemon.supervisor;
 
 import java.io.BufferedReader;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.io.Reader;
 import java.io.Writer;
 import java.lang.ProcessBuilder.Redirect;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -182,12 +180,28 @@ public abstract class Container implements Killable {
     
     private boolean isWindowsProcessAlive(long pid, String user) throws IOException {
         boolean ret = false;
-        ProcessBuilder pb = new ProcessBuilder("tasklist", "/nh", "/fi", "pid eq" + pid);
+        ProcessBuilder pb = new ProcessBuilder("tasklist", "/fo", "list", "/fi", "pid eq " + pid, "/v");
         pb.redirectError(Redirect.INHERIT);
         Process p = pb.start();
         try (BufferedReader in = new BufferedReader(new InputStreamReader(p.getInputStream()))) {
-            if (in.readLine() != null) {
-                ret = true;
+            String read;
+            while ((read = in.readLine()) != null) {
+                if (read.contains("User Name:")) { //Check for : in case someone called their user "User Name"
+                    //This line contains the user name for the pid we're looking up
+                    //Example line: "User Name:    exampleDomain\exampleUser"
+                    List<String> userNameLineSplitOnWhitespace = Arrays.asList(read.split(":"));
+                    if(userNameLineSplitOnWhitespace.size() == 2){
+                        String processUser = userNameLineSplitOnWhitespace.get(1).trim();
+                        if(user.equals(processUser)){
+                            ret = true;
+                        } else {
+                            LOG.info("Found {} running as {}, but expected it to be {}", pid, processUser, user);
+                        }
+                    } else {
+                        LOG.error("Received unexpected output from tasklist command. Expected one colon in user name line. Line was {}", read);
+                    }
+                    break;
+                }
             }
         }
         return ret;


### PR DESCRIPTION
… username

I've only been able to check this on a Windows 10 install, and then only by testing isWindowsProcessAlive in isolation (i.e. I tested the function manually from a main method). 

I'm assuming that when Windows users configure their worker user, they include the domain part.
